### PR TITLE
44-semantic-search-configuration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -73,4 +73,4 @@ FINESSE_BACKEND_AZURE_SEARCH_TRANSFORM_MAP={"id": "/id", "title": "/title", "sco
 
 # Parameters for Azure Cognitive Search queries. Represented as a JSON string. Optional.
 # Consult https://learn.microsoft.com/en-us/python/api/azure-search-documents/azure.search.documents.searchclient?view=azure-python#azure-search-documents-searchclient-search
-FINESSE_BACKEND_AZURE_SEARCH_PARAMS={"highlight_fields": "content", "highlight_pre_tag": "<strong>", "highlight_post_tag": "</strong>"}
+FINESSE_BACKEND_AZURE_SEARCH_PARAMS={"highlight_fields": "content", "highlight_pre_tag": "<strong>", "highlight_post_tag": "</strong>", "query_type": "semantic", "semantic_configuration_name": "Semantic-config-public-guidance-docs"}

--- a/app/blueprints/search.py
+++ b/app/blueprints/search.py
@@ -57,8 +57,10 @@ def get_non_empty_query():
 @search_blueprint.route("/azure", methods=["POST"])
 def search_azure():
     config = current_app.config
-    skip = request.args.get("skip", default=config["AZURE_SEARCH_SKIP"], type=int)
-    top = request.args.get("top", default=config["AZURE_SEARCH_TOP"], type=int)
+    skip = request.args.get(
+        "skip", default=config["DEFAULT_AZURE_SEARCH_SKIP"], type=int
+    )
+    top = request.args.get("top", default=config["DEFAULT_AZURE_SEARCH_TOP"], type=int)
     query = get_non_empty_query()
     search_params = {**config["AZURE_SEARCH_PARAMS"], "skip": skip, "top": top}
     client = config["AZURE_SEARCH_CLIENT"]

--- a/app/config.py
+++ b/app/config.py
@@ -2,20 +2,23 @@ import json
 import os
 from typing import TypedDict
 
-import app.constants as constants
 from azure.core.credentials import AzureKeyCredential
 from azure.search.documents import SearchClient
 from dotenv import load_dotenv
+
+import app.constants as constants
 
 load_dotenv()
 
 
 class Config(TypedDict):
-    AZURE_SEARCH_SKIP: int
-    AZURE_SEARCH_TOP: int
     AZURE_SEARCH_CLIENT: SearchClient
+    DEFAULT_AZURE_SEARCH_SKIP: int
+    DEFAULT_AZURE_SEARCH_TOP: int
     AZURE_SEARCH_PARAMS: dict
     AZURE_SEARCH_TRANSFORM_MAP: dict
+    AZURE_SEMANTIC_CONFIGURATION_NAME: str
+    AZURE_QUERY_TYPE: str
     FINESSE_DATA_URL: str
     DEBUG: bool
     ERROR_EMPTY_QUERY: str
@@ -45,8 +48,8 @@ def create_config() -> Config:
     )
 
     return {
-        "AZURE_SEARCH_SKIP": constants.DEFAULT_AZURE_SEARCH_SKIP,
-        "AZURE_SEARCH_TOP": constants.DEFAULT_AZURE_SEARCH_TOP,
+        "DEFAULT_AZURE_SEARCH_SKIP": constants.DEFAULT_AZURE_SEARCH_SKIP,
+        "DEFAULT_AZURE_SEARCH_TOP": constants.DEFAULT_AZURE_SEARCH_TOP,
         "AZURE_SEARCH_CLIENT": azure_search_client,
         "AZURE_SEARCH_PARAMS": azure_search_params,
         "AZURE_SEARCH_TRANSFORM_MAP": azure_search_transform_map,

--- a/tests/test_azure_search.py
+++ b/tests/test_azure_search.py
@@ -21,8 +21,8 @@ class TestAzureSearch(unittest.TestCase):
         self.config: Config = {
             "DEBUG": True,
             "TESTING": True,
-            "AZURE_SEARCH_SKIP": DEFAULT_AZURE_SEARCH_SKIP,
-            "AZURE_SEARCH_TOP": DEFAULT_AZURE_SEARCH_TOP,
+            "DEFAULT_AZURE_SEARCH_SKIP": DEFAULT_AZURE_SEARCH_SKIP,
+            "DEFAULT_AZURE_SEARCH_TOP": DEFAULT_AZURE_SEARCH_TOP,
             "AZURE_SEARCH_PARAMS": DEFAULT_AZURE_SEARCH_PARAMS,
             "AZURE_SEARCH_CLIENT": Mock(),
             "SANITIZE_PATTERN": DEFAULT_SANITIZE_PATTERN,
@@ -64,8 +64,8 @@ class TestAzureSearch(unittest.TestCase):
                 "default azure query",
                 self.config["AZURE_SEARCH_CLIENT"],
                 {
-                    "skip": self.config["AZURE_SEARCH_SKIP"],
-                    "top": self.config["AZURE_SEARCH_TOP"],
+                    "skip": self.config["DEFAULT_AZURE_SEARCH_SKIP"],
+                    "top": self.config["DEFAULT_AZURE_SEARCH_TOP"],
                     **self.config["AZURE_SEARCH_PARAMS"],
                 },
                 self.config["AZURE_SEARCH_TRANSFORM_MAP"],


### PR DESCRIPTION
Closes #44: Update Configurations for Semantic Search

- [x] update configuration and documentation (check `.env.template`)
- [x] test that the search function is called with the right params