### PR TITLE
issue #66: update llamaindex schema to `v_0_0_2`

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -76,10 +76,10 @@ FINESSE_BACKEND_AZURE_SEARCH_TRANSFORM_MAP={"id": "/id", "title": "/title", "sco
 FINESSE_BACKEND_AZURE_SEARCH_PARAMS={"highlight_fields": "content", "highlight_pre_tag": "<strong>", "highlight_post_tag": "</strong>", "query_type": "semantic", "semantic_configuration_name": "Semantic-config-public-guidance-docs"}
 
 # Parameters for configuring the model used for embeddings. Contact your cloud admin for secrets.
-FINESSE_BACKEND_LLAMAINDEX_EMBED_MODEL_PARAMS='{"api_key": "<openai_api_key>", "api_version": "2023-07-01-preview", "azure_endpoint": "<azure_endpoint>", "deployment_name": "ada", "model": "text-embedding-ada-002"}'
+FINESSE_BACKEND_LLAMAINDEX_EMBED_MODEL_PARAMS={"api_key": "<openai_api_key>", "api_version": "2023-07-01-preview", "azure_endpoint": "<azure_endpoint>", "deployment_name": "ada", "model": "text-embedding-ada-002"}
 
 # Parameters for the vector store configuration. Contact your cloud admin for secrets.
-FINESSE_BACKEND_LLAMAINDEX_VECTOR_STORE_PARAMS='{"database": "llamaindex_db_legacy", "schema_name": "v_0_0_1", "embed_dim": 1536, "host": "<postgres_host>", "password": "<postgres_password>", "port": "5432", "user": "<postgres_user>"}'
+FINESSE_BACKEND_LLAMAINDEX_VECTOR_STORE_PARAMS={"database": "llamaindex_db_legacy", "schema_name": "v_0_0_2", "embed_dim": 1536, "host": "<postgres_host>", "password": "<postgres_password>", "port": "5432", "user": "<postgres_user>"}
 
 # Paths for transforming search results from the vector store.
-FINESSE_BACKEND_LLAMAINDEX_TRANS_PATHS='{"chunk_id": "node/metadata/chunk_id", "content": "node/text", "id": "node/metadata/id", "last_updated": "node/metadata/last_updated", "llamaindex_id": "node/id_", "llamaindex_score": "score", "score": "node/metadata/score", "subtitle": "node/metadata/subtitle", "title": "node/metadata/title", "tokens_count": "node/metadata/tokens_count", "url": "node/metadata/url"}'
+FINESSE_BACKEND_LLAMAINDEX_TRANS_PATHS={"id": "node/id_", "url": "node/metadata/url", "title": "node/metadata/title", "last_updated": "node/metadata/last_crawled", "score": "score", "content": "node/text"}


### PR DESCRIPTION
#66

- [x] update gh envs
- [x] update envs in vault
- [x] point deployment to new envs version
- [ ] redeploy once ai-cfia/llamaindex-db#22 is merged
- [x] update documentation
